### PR TITLE
 Updating model addresses from GL:alexdesiqueira/mothra-models to GL:mothra/mothra-data

### DIFF
--- a/butterfly/connection.py
+++ b/butterfly/connection.py
@@ -8,15 +8,15 @@ import socket
 
 # defining global constants.
 URL_MODEL = {
-    'id_gender' : 'https://gitlab.com/alexdesiqueira/mothra-models/-/raw/main/models/id_gender/id_gender.pkl',
-    'id_position' : 'https://gitlab.com/alexdesiqueira/mothra-models/-/raw/main/models/id_position/id_position.pkl',
-    'segmentation' : 'https://gitlab.com/alexdesiqueira/mothra-models/-/raw/main/models/segmentation/segmentation.pkl'
+    'id_gender' : 'https://gitlab.com/mothra/mothra-data/-/raw/main/models/id_gender/id_gender.pkl',
+    'id_position' : 'https://gitlab.com/mothra/mothra-data/-/raw/main/models/id_position/id_position.pkl',
+    'segmentation' : 'https://gitlab.com/mothra/mothra-data/-/raw/main/models/segmentation/segmentation.pkl'
     }
 
 URL_HASH = {
-    'id_gender' : 'https://gitlab.com/alexdesiqueira/mothra-models/-/raw/main/models/id_gender/SHA256SUM-id_gender',
-    'id_position' : 'https://gitlab.com/alexdesiqueira/mothra-models/-/raw/main/models/id_position/SHA256SUM-id_position',
-    'segmentation' : 'https://gitlab.com/alexdesiqueira/mothra-models/-/raw/main/models/segmentation/SHA256SUM-segmentation'
+    'id_gender' : 'https://gitlab.com/mothra/mothra-data/-/raw/main/models/id_gender/SHA256SUM-id_gender',
+    'id_position' : 'https://gitlab.com/mothra/mothra-data/-/raw/main/models/id_position/SHA256SUM-id_position',
+    'segmentation' : 'https://gitlab.com/mothra/mothra-data/-/raw/main/models/segmentation/SHA256SUM-segmentation'
     }
 
 


### PR DESCRIPTION
Update on #66: model addresses go from [GL:alexdesiqueira/mothra-models](https://gitlab.com/alexdesiqueira/mothra-models) to [GL:mothra/mothra-data](https://gitlab.com/mothra/mothra-data/).