### PR TITLE
[WIP] Updating fastai and segmentation models

### DIFF
--- a/butterfly/binarization.py
+++ b/butterfly/binarization.py
@@ -29,16 +29,6 @@ RULER_CROP_MARGIN = 0.025
 # Used in find_tags_edge. Percent of width of the image
 REGION_CUTOFF = 1/3
 
-# Size of disk used in dilation to get connect butterfly regions
-# Used during getting butterfly bounding box in grabcut
-DILATION_SIZE = 10
-
-# Image downsize percentage used to improve grabcut speed
-GRABCUT_RESCALE_FACTOR = 0.25
-
-# Number of iterations used in grabcut
-GRABCUT_ITERATIONS = 10
-
 
 def _convert_image_to_tensor(image):
     """Auxiliary function. Receives an RGB image and convert it to be processed
@@ -186,7 +176,7 @@ def return_largest_region(img_bin):
 
 
 @memory.cache(ignore=['axes'])
-def main(image_rgb, top_ruler, grabcut=False, unet=False, axes=None):
+def main(image_rgb, top_ruler, unet=False, axes=None):
     """Binarizes and crops properly image_rgb
 
     Arguments

--- a/pipeline.py
+++ b/pipeline.py
@@ -206,7 +206,6 @@ def main():
                         action='store_true',
                         help='If entered detailed images are plotted to the\
                         output folder')
-
     # Input path
     parser.add_argument('-i', '--input',
                         type=str,
@@ -214,7 +213,6 @@ def main():
                         file (extension txt) containing paths',
                         required=False,
                         default='raw_images')
-
     # Output path
     parser.add_argument('-o', '--output_folder',
                         type=str,
@@ -239,11 +237,6 @@ def main():
                         type=str,
                         help='Path of the resulting csv file',
                         default='results.csv')
-
-    # Grabcut
-    parser.add_argument('-g', '--grabcut',
-                        action='store_true',
-                        help='Use grabcut in binarization step')
 
     # U-nets
     parser.add_argument('-u', '--unet',
@@ -307,7 +300,7 @@ def main():
         axes = create_layout(len(pipeline_process), plot_level)
 
         # binarizing ruler, tags and Lepidoptera.
-        img_binary = binarization.main(image_rgb, top_ruler, args.grabcut, args.unet, axes)
+        img_binary = binarization.main(image_rgb, top_ruler, args.unet, axes)
 
         # separating elements in the input image.
         bin_lepidoptera, bin_ruler, bin_tags = _sep_binary_elements(img_binary)

--- a/pipeline.py
+++ b/pipeline.py
@@ -105,6 +105,27 @@ def read_orientation(image_path):
         return None
 
 
+def separate_binary_elements(img_binary):
+    """Separate the elements constutient of the binary input image.
+
+    Parameters
+    ----------
+    img_binary : (M, N) ndarray
+        Binary input image.
+
+    Returns
+    -------
+    bin_lepidoptera : (M, N) ndarray
+        Image contaning the Lepidoptera.
+    bin_ruler : (M, N) ndarray
+        Image contaning the ruler.
+    bin_tags : (M, N) ndarray
+        Image contaning the tags.
+    """
+
+    return bin_lepidoptera, bin_ruler, bin_tags
+
+
 def _check_aux_file(filename):
     """Helper function. Checks if filename exists; if yes, adds a number to
     it."""
@@ -285,15 +306,21 @@ def main():
 
         axes = create_layout(len(pipeline_process), plot_level)
 
+        # binarizing ruler, tags and Lepidoptera.
+        img_binary = binarization.main(image_rgb, top_ruler, args.grabcut, args.unet, axes)
+
+        # separating elements in the input image.
+        bin_lepidoptera, bin_ruler, bin_tags = _sep_binary_elements(img_binary)
+
         for step in pipeline_process:
             if step == 'ruler_detection':
-                T_space, top_ruler = ruler_detection.main(image_rgb, axes)
+                T_space, top_ruler = ruler_detection.main(image_rgb, bin_ruler, axes)
 
-            elif step == 'binarization':
-                binary = binarization.main(image_rgb, top_ruler, args.grabcut, args.unet, axes)
+            # elif step == 'binarization':
+
 
             elif step == 'measurements':
-                points_interest = tracing.main(binary, axes)
+                points_interest = tracing.main(img_binary, axes)
                 dist_pix, dist_mm = measurement.main(points_interest, T_space,
                                                      axes)
                 # measuring position and gender

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ scipy
 pandas
 pytest-timeout
 joblib
-fastai < 2
+fastai
 pooch
 exif

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 matplotlib
 scikit-image
-opencv-python
 numpy
 scipy
 pandas


### PR DESCRIPTION
In this PR, we:
* update `fastai` version to 2, and refactor all necessary code.
* rewrite the deep learning segmentation models: instead of returning only the Lepidoptera, they now recognize the ruler and labels as well.
* remove classical and `grabcut` segmentation options, leaving only U-nets.