### PR TITLE
Removing grabcut and classic segmentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ The following parameters can be used as input arguments for `pipeline.py`:
 * `-s`, `--stage` : The stage which to run the pipeline until. Options are `'ruler_detection'`, `'binarization'`, and `'measurements'`. Default is `measurement` (running to completion). Running the pipeline and stopping at an earlier stage can be useful for debugging.
 * `-csv`, `--path_csv` :  Path of `.csv` file for the measurement results. (Default is `results.csv`).
 * `-dpi` : Optional argument to specify resolution of the output image. (Default is `300`.)
-* `-g`, `--grabcut` : Use OpenCV's grabcut method in order to improve binarization on blue butterflies.
-* `-u`, `--unet` : Use the U-net deep neural network in the binarization step.
 
 ## Measurement results
 
@@ -72,9 +70,9 @@ Resulting files:
 
 Running the command
 ```
-$ python pipeline.py -p -u -i ../mothra-data -o ../test_output -csv ../test_output/results.csv
+$ python pipeline.py -p -i ../mothra-data -o ../test_output -csv ../test_output/results.csv
 ```
-in `/mothra` will run the pipeline using the U-net deep neural network on the example data in the folder `/mothra-data`. The file locations should look like this:
+in `/mothra` will run the pipeline on the example data in the folder `/mothra-data`. The file locations should look like this:
 ```
 /mothra
     ...

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Running the command
 ```
 $ python pipeline.py -p -i ../mothra-data -o ../test_output -csv ../test_output/results.csv
 ```
-in `/mothra` will run the pipeline on the example data in the folder `/mothra-data`. The file locations should look like this:
+in `./mothra` will run the pipeline on the example data in the folder `/mothra-data`. The file locations should look like this:
 ```
 /mothra
     ...

--- a/butterfly/tests/test_binarization.py
+++ b/butterfly/tests/test_binarization.py
@@ -76,24 +76,6 @@ def test_missing_tags(fake_butterfly_no_tags):
     assert (result >= 399)
 
 
-def test_grabcut(fake_butterfly_layout):
-    # mostly as test_main, but testing grabcut method does not interfere with
-    # expected behavior
-    butterfly, (rows, cols) = fake_butterfly_layout
-    picture_2d = butterfly.astype(np.uint8)
-    picture_3d = np.dstack((picture_2d,
-                            1/2 * picture_2d,
-                            1/4 * picture_2d))  # fake RGB image
-    result = binarization.main(picture_3d, 230, grabcut=True)
-    y_where, x_where = np.where(result)
-    x_where_min, x_where_max = np.min(x_where), np.max(x_where)
-    y_where_min, y_where_max = np.min(y_where), np.max(y_where)
-
-    # assert the "butterfly" is included in the cropped and binarized result
-    assert((rows - 10 <= y_where_max - y_where_min <= rows + 10) and
-           (cols - 10 <= x_where_max - x_where_min <= cols + 10))
-
-
 def test_unet():
     """Tests U-net segmentation."""
     bfly_rgb = imread('./butterfly/tests/test_files/test_input/BMNHE_1297240_147563_dbf1346219110b416ff10347b45e070b1e0d116d.png.rgb')
@@ -102,19 +84,3 @@ def test_unet():
     output = binarization.unet_binarization(bfly_rgb, weights='./models/segmentation.pkl')
 
     assert np.allclose(img_as_bool(output), img_as_bool(bfly_bin))
-
-
-def test_main(fake_butterfly_layout):
-    butterfly, (rows, cols) = fake_butterfly_layout
-    picture_2d = butterfly.astype(np.uint8)
-    picture_3d = np.dstack((picture_2d,
-                            1/2 * picture_2d,
-                            1/4 * picture_2d))  # fake RGB image
-    result = binarization.main(picture_3d, 230)
-    y_where, x_where = np.where(result)
-    x_where_min, x_where_max = np.min(x_where), np.max(x_where)
-    y_where_min, y_where_max = np.min(y_where), np.max(y_where)
-
-    # assert the "butterfly" is included in the cropped and binarized result
-    assert((rows - 5 <= y_where_max - y_where_min <= rows + 5) and
-           (cols - 5 <= x_where_max - x_where_min <= cols + 5))

--- a/pipeline.py
+++ b/pipeline.py
@@ -219,11 +219,6 @@ def main():
                         help='Path of the resulting csv file',
                         default='results.csv')
 
-    # Grabcut
-    parser.add_argument('-g', '--grabcut',
-                        action='store_true',
-                        help='Use grabcut in binarization step')
-
     # U-nets
     parser.add_argument('-u', '--unet',
                         action='store_true',
@@ -290,7 +285,7 @@ def main():
                 T_space, top_ruler = ruler_detection.main(image_rgb, axes)
 
             elif step == 'binarization':
-                binary = binarization.main(image_rgb, top_ruler, args.grabcut, args.unet, axes)
+                binary = binarization.main(image_rgb, top_ruler, args.unet, axes)
 
             elif step == 'measurements':
                 points_interest = tracing.main(binary, axes)

--- a/pipeline.py
+++ b/pipeline.py
@@ -219,10 +219,6 @@ def main():
                         help='Path of the resulting csv file',
                         default='results.csv')
 
-    # U-nets
-    parser.add_argument('-u', '--unet',
-                        action='store_true',
-                        help='Use U-nets in binarization step')
     args = parser.parse_args()
 
     # Initialization
@@ -285,7 +281,7 @@ def main():
                 T_space, top_ruler = ruler_detection.main(image_rgb, axes)
 
             elif step == 'binarization':
-                binary = binarization.main(image_rgb, top_ruler, args.unet, axes)
+                binary = binarization.main(image_rgb, top_ruler, axes)
 
             elif step == 'measurements':
                 points_interest = tracing.main(binary, axes)


### PR DESCRIPTION
In this PR, we remove ~classical~classic (Otsu threshold) and grabcut segmentation options, leaving only U-nets.
