### PR TITLE
Adding albumentations to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+albumentations
 matplotlib
 scikit-image
 numpy


### PR DESCRIPTION
Small fix. Adding `albumentations` to `requirements.txt`.