### PR TITLE
Fixing bug in shoulder detection

### DIFF
--- a/mothra/identification.py
+++ b/mothra/identification.py
@@ -81,18 +81,19 @@ def main(image_rgb):
         Gender of the lepidopteran, or N/A if position is `upside_down`.
     """
     print('Identifying position and gender...')
-    pos_and_gender = predict_gender(image_rgb, weights=WEIGHTS_GENDER)
+    try:
+        pos_and_gender = predict_gender(image_rgb, weights=WEIGHTS_GENDER)
 
-    if pos_and_gender == 'upside_down':
-        position = pos_and_gender
+        if pos_and_gender == 'upside_down':
+            position = pos_and_gender
+            gender = 'N/A'
+            print(f'* Position: {position}\n * Gender: {gender}')
+        else:
+            position = 'right-side_up'
+            gender = pos_and_gender
+            print(f'* Position: {position}\n* Gender: {gender}')
+    except AttributeError:  # 'Compose' object has no attribute 'is_check_args'
+        position = 'N/A'
         gender = 'N/A'
-
-        print(f'* Position: {position}\n * Gender: {gender}')
-
-    else:
-        position = 'right-side_up'
-        gender = pos_and_gender
-
-        print(f'* Position: {position}\n* Gender: {gender}')
 
     return position, gender

--- a/mothra/tests/test_pipeline.py
+++ b/mothra/tests/test_pipeline.py
@@ -12,7 +12,7 @@ from skimage.io import imread
 from skimage.util import img_as_float
 
 
-PATH_TEST_FILES = 'mothra/tests/test_files/'
+PATH_TEST_FILES = 'mothra/tests/test_files'
 TEST_CSV_FILE = f'{PATH_TEST_FILES}/test_file.csv'
 TEST_INPUT_FILE = f'{PATH_TEST_FILES}/input_file.txt'
 TEST_INPUT_IMAGES = glob(f'{PATH_TEST_FILES}/test_input/*.JPG')

--- a/mothra/tracing.py
+++ b/mothra/tracing.py
@@ -99,7 +99,7 @@ def detect_inner_pix(half_binary, outer_pix, side):
 
     markers, _ = ndi.label(focus_inv, ndi.generate_binary_structure(2, 1))
     regions = regionprops(markers)
-    areas = [r.area for r in regions]
+
     # if idx in regions is not 0, downside is considered for inner_pix, instead of upside
     coords = regions[0].coords
     y_max = np.max(coords[:, 0])

--- a/mothra/tracing.py
+++ b/mothra/tracing.py
@@ -87,6 +87,16 @@ def detect_inner_pix(half_binary, outer_pix, side):
     -------
     inner_pix : 2D array
         relative coordinates of the inner pixel (r, c)
+
+    Notes
+    -----
+    This function returns `inner_pix` from the following steps:
+    1. Obtains `focus`, the region where to look for `inner_pix`;
+    2. Gathers `focus_inv`, the inverse of `focus`, and returns the
+       information on its regions;
+    3. From the top region of `focus_inv`, the shoulder of the
+       lepidopteran — the farthest point at the rows — is chosen
+       as `inner_pix`.
     """
     lower_bound = int(half_binary.shape[0]*0.75)
 

--- a/mothra/tracing.py
+++ b/mothra/tracing.py
@@ -100,8 +100,8 @@ def detect_inner_pix(half_binary, outer_pix, side):
     markers, _ = ndi.label(focus_inv, ndi.generate_binary_structure(2, 1))
     regions = regionprops(markers)
     areas = [r.area for r in regions]
-    idx_max = np.argmax(areas)
-    coords = regions[idx_max].coords
+    # if idx in regions is not 0, downside is considered for inner_pix, instead of upside
+    coords = regions[0].coords
     y_max = np.max(coords[:, 0])
     mask = (coords[:, 0] == y_max)
     selection = coords[mask]
@@ -110,9 +110,9 @@ def detect_inner_pix(half_binary, outer_pix, side):
     else:
         idx = np.argmin(selection[:, 1])
 
-    outer_pix = selection[idx]
+    inner_pix = selection[idx]
 
-    return outer_pix
+    return inner_pix
 
 
 def split_picture(binary):

--- a/mothra/tracing.py
+++ b/mothra/tracing.py
@@ -110,7 +110,8 @@ def detect_inner_pix(half_binary, outer_pix, side):
     markers, _ = ndi.label(focus_inv, ndi.generate_binary_structure(2, 1))
     regions = regionprops(markers)
 
-    # if idx in regions is not 0, downside is considered for inner_pix, instead of upside
+    # if idx in regions is not 0, bottom region is considered for inner_pix,
+    # instead of top region
     coords = regions[0].coords
     y_max = np.max(coords[:, 0])
     mask = (coords[:, 0] == y_max)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pytest-timeout
 joblib
 fastai == 2.4.1
 torch == 1.8.1
+torchvision == 0.9.1
 pooch
 exif

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pandas
 pytest-timeout
 joblib
 fastai == 2.4.1
+torch == 1.8.1
 pooch
 exif


### PR DESCRIPTION
In `tracing.detect_inner_pix`, `idx_max = np.argmax(areas)` returns the region with the largest area. When the bottom background of the wing is larger, `detect_inner_pix` tries to find an inner pix on the _bottom_ of the image:

![image](https://user-images.githubusercontent.com/5776022/135701283-12bf4ad2-6377-463b-8180-7cf6f9b90d0e.png)


This way, we have the issues described by Phil:

![BMNHE_502318](https://user-images.githubusercontent.com/5776022/135701189-9262f9ea-0707-4a0d-8c12-88a9a38b976b.JPG)

Ensuring that the pipeline uses the first region, this issue is solved:

![BMNHE_502318](https://user-images.githubusercontent.com/5776022/135701297-a85f7304-0b8f-44c2-9b70-a0a9000a8552.JPG)


