### PR TITLE
Locking python version on requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python_version >= 3.7, <= 3.9
+python >= 3.7, <= 3.9
 albumentations == 1.0.3
 matplotlib
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python_version >= 3.7, <= 3.9
 albumentations == 1.0.3
 matplotlib
 scikit-image


### PR DESCRIPTION
According to Tiffany Ki's feedback,
> with the requirements installation, I also found that I could only run it in python 3.8 and not python 3.10 due to torch 1.8.1 not being able to be installed.

For now, let's keep python between 3.7 to 3.9 — the versions we have tests for.