### PR TITLE
Document the argument `--auto_rotate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following parameters can be used as input arguments for `pipeline.py`:
 * `-i`, `--input` : A single image input or a directory of images to be analyzed. (Default is `input_images`).
 * `-o`, `--output_folder` : The output directory in which the result images will be outputted. (Default is `outputs`).
 * `-s`, `--stage` : The stage which to run the pipeline until. Options are `'ruler_detection'`, `'binarization'`, and `'measurements'`. Default is `measurement` (running to completion). Running the pipeline and stopping at an earlier stage can be useful for debugging.
+* `-ar`, `--auto_rotate` : Enable automatic rotation of input images, according to the information in the EXIF tag.
 * `-csv`, `--path_csv` :  Path of `.csv` file for the measurement results. (Default is `results.csv`).
 * `-dpi` : Optional argument to specify resolution of the output image. (Default is `300`.)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -59,7 +59,8 @@ def main():
     # Enable auto-rotation
     parser.add_argument('-ar', '--auto_rotate',
                         action='store_true',
-                        help='Enable rotation of input images based on EXIF tag')
+                        help='Enable automatic rotation of input images\
+                        based on EXIF tag')
 
     # Dots per inch
     parser.add_argument('-dpi',

--- a/pipeline.py
+++ b/pipeline.py
@@ -47,6 +47,7 @@ def main():
                         help='Output path for raw image',
                         required=False,
                         default='outputs')
+
     # Stage
     parser.add_argument('-s', '--stage',
                         type=str,
@@ -54,6 +55,12 @@ def main():
                         'measurements'",
                         required=False,
                         default='measurements')
+
+    # Enable auto-rotation
+    parser.add_argument('-ar', '--auto_rotate',
+                        action='store_true',
+                        help='Enable rotation of input images based on EXIF tag')
+
     # Dots per inch
     parser.add_argument('-dpi',
                         type=int,
@@ -70,11 +77,6 @@ def main():
     parser.add_argument('--cache',
                         action='store_true',
                         help='Enable computation cache (useful when developing algorithms)')
-
-    # Enable auto-rotation
-    parser.add_argument('--auto_rotate',
-                        action='store_true',
-                        help='Enable rotation of input images based on EXIF tag')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
In this PR, we:
- add documentation for the argument `--auto_rotate` in the README.
- add a shortcut to `--auto_rotate`, `-ar`.