### PR TITLE
Add newline to output

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -128,7 +128,7 @@ def main():
             axes = plotting.create_layout(len(pipeline_process), plot_level)
 
             image_name = os.path.basename(image_path)
-            print(f'Image {i+1}/{number_of_images} : {image_name}')
+            print(f'\nImage {i+1}/{number_of_images} : {image_name}')
 
             image_rgb = imread(image_path)
 


### PR DESCRIPTION
Small fix. Will help adding a newline before output, so we don't have a large chunk of text like this:

```
Probabilities:
* upside_down: 0.0
* female: 0.0002
* male: 0.9998
Image 13/21 : small1_rotate_crop_crop.jpg
Cannot evaluate orientation for ./no_colour_bar_test/small1_rotate_crop_crop.jpg.
Image angle: None deg
```

This text would be 
```
Probabilities:
* upside_down: 0.0
* female: 0.0002
* male: 0.9998

Image 13/21 : small1_rotate_crop_crop.jpg
Cannot evaluate orientation for ./no_colour_bar_test/small1_rotate_crop_crop.jpg.
Image angle: None deg
```
instead, separating the data of each image.